### PR TITLE
Add workflow to create release tags automatically

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,113 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to create tag for (leave empty for current branch)'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write  # Required to create and push tags
+      actions: read    # Required to read workflow context
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Fetch all history and tags
+        ref: ${{ inputs.branch || github.ref }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Setup Git
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+    
+    - name: Create and push tag
+      id: create-tag
+      run: |
+        # Get current branch name
+        if [ -n "${{ inputs.branch }}" ]; then
+          BRANCH_NAME="${{ inputs.branch }}"
+        else
+          BRANCH_NAME=$(git branch --show-current)
+        fi
+        
+        echo "Current branch: $BRANCH_NAME"
+        
+        # Get current commit
+        CURRENT_COMMIT=$(git rev-parse HEAD)
+        echo "Current commit: $CURRENT_COMMIT"
+        
+        # Check if there's already a tag with format BRANCH_NAME.* on the current commit
+        EXISTING_BRANCH_TAG=$(git tag --points-at $CURRENT_COMMIT | grep "^${BRANCH_NAME}\." | head -1)
+        
+        if [ -n "$EXISTING_BRANCH_TAG" ]; then
+          echo "Existing tag found on current commit: $EXISTING_BRANCH_TAG"
+          TAG_TO_USE=$EXISTING_BRANCH_TAG
+          echo "No new tag needed, using existing tag: $TAG_TO_USE"
+        else
+          echo "No tag with format ${BRANCH_NAME}.* found on current commit, creating new tag"
+          
+          # List existing tags for this branch (format: BRANCH_NAME.*)
+          EXISTING_TAGS=$(git tag -l "${BRANCH_NAME}.*" | sort -V)
+          
+          if [ -z "$EXISTING_TAGS" ]; then
+            # First tag for this branch
+            NEW_TAG="${BRANCH_NAME}.1"
+            echo "First tag for branch: $NEW_TAG"
+          else
+            # Find the highest tag and increment
+            HIGHEST_TAG=$(echo "$EXISTING_TAGS" | tail -1)
+            echo "Highest existing tag: $HIGHEST_TAG"
+            
+            # Extract the number and increment
+            LAST_NUMBER=$(echo $HIGHEST_TAG | cut -d'.' -f2)
+            NEW_NUMBER=$((LAST_NUMBER + 1))
+            NEW_TAG="${BRANCH_NAME}.${NEW_NUMBER}"
+            echo "New tag calculated: $NEW_TAG"
+          fi
+          
+          # Create the tag
+          git tag -a $NEW_TAG -m "Release $NEW_TAG"
+          echo "Tag $NEW_TAG created"
+          
+          # Push the tag
+          git push origin $NEW_TAG
+          echo "Tag $NEW_TAG pushed to origin"
+          
+          TAG_TO_USE=$NEW_TAG
+        fi
+        
+        echo "Final tag used: $TAG_TO_USE"
+        
+        # Ensure the tag is pushed (in case it was created but not pushed)
+        git push origin $TAG_TO_USE || echo "Tag $TAG_TO_USE already exists on remote"
+        
+        # Set output for potential use in other steps
+        echo "tag=$TAG_TO_USE" >> $GITHUB_OUTPUT
+        
+        # Create a summary
+        echo "## Release Tag Summary" >> $GITHUB_STEP_SUMMARY
+        echo "- **Branch**: $BRANCH_NAME" >> $GITHUB_STEP_SUMMARY
+        echo "- **Commit**: $CURRENT_COMMIT" >> $GITHUB_STEP_SUMMARY
+        echo "- **Tag**: $TAG_TO_USE" >> $GITHUB_STEP_SUMMARY
+        
+        if [ "$TAG_TO_USE" = "$NEW_TAG" ]; then
+          echo "- **Action**: New tag created and pushed" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "- **Action**: Using existing tag (no new tag needed)" >> $GITHUB_STEP_SUMMARY
+        fi
+      
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    outputs:
+      tag: ${{ steps.create-tag.outputs.tag }}


### PR DESCRIPTION
Introduces a GitHub Actions workflow that creates and pushes incremented release tags for a specified or current branch. The workflow checks for existing tags, increments as needed, and outputs a summary for use in subsequent steps.